### PR TITLE
Made the `SalesOrderEndpoint::cancel` idempotent

### DIFF
--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -23,6 +23,7 @@ use Setono\PeakWMS\Client\Endpoint\StockEndpoint;
 use Setono\PeakWMS\Client\Endpoint\StockEndpointInterface;
 use Setono\PeakWMS\Client\Endpoint\WebhookEndpoint;
 use Setono\PeakWMS\Client\Endpoint\WebhookEndpointInterface;
+use Setono\PeakWMS\Exception\BadRequestException;
 use Setono\PeakWMS\Exception\InternalServerErrorException;
 use Setono\PeakWMS\Exception\NotAuthorizedException;
 use Setono\PeakWMS\Exception\NotFoundException;
@@ -268,6 +269,7 @@ final class Client implements ClientInterface, LoggerAwareInterface
             return;
         }
 
+        BadRequestException::assert($response);
         NotAuthorizedException::assert($response);
         NotFoundException::assert($response);
         TooManyRequestsException::assert($response);

--- a/src/Client/Endpoint/SalesOrderEndpoint.php
+++ b/src/Client/Endpoint/SalesOrderEndpoint.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Setono\PeakWMS\Client\Endpoint;
 
 use Setono\PeakWMS\DataTransferObject\SalesOrder\SalesOrder;
+use Setono\PeakWMS\Exception\BadRequestException;
 
 /**
  * @extends Endpoint<SalesOrder>
@@ -25,7 +26,13 @@ final class SalesOrderEndpoint extends Endpoint implements SalesOrderEndpointInt
 
     public function cancel(string $id): void
     {
-        $this->client->put(sprintf('%s/%s/cancel', $this->endpoint, $id));
+        try {
+            $this->client->put(sprintf('%s/%s/cancel', $this->endpoint, $id));
+        } catch (BadRequestException $e) {
+            if (!str_contains($e->getMessage(), 'cannot be cancelled because it is in state CANCELLED')) {
+                throw $e;
+            }
+        }
     }
 
     protected static function getDataClass(): string

--- a/src/Exception/BadRequestException.php
+++ b/src/Exception/BadRequestException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\PeakWMS\Exception;
+
+use Psr\Http\Message\ResponseInterface;
+
+final class BadRequestException extends ResponseAwareException
+{
+    public static function assert(ResponseInterface $response): void
+    {
+        if ($response->getStatusCode() === 400) {
+            throw new self($response);
+        }
+    }
+}

--- a/src/Exception/ResponseAwareException.php
+++ b/src/Exception/ResponseAwareException.php
@@ -10,22 +10,37 @@ abstract class ResponseAwareException extends \RuntimeException
 {
     private ResponseInterface $response;
 
+    private int $statusCode;
+
     public function __construct(ResponseInterface $response)
     {
-        $message = sprintf('The status code was: %d.', $response->getStatusCode());
-
         $body = (string) $response->getBody();
+        $message = sprintf('The request failed with status code %d and body: %s', $response->getStatusCode(), $body);
+
         if ('' !== $body) {
-            $message .= sprintf(' The body was: %s.', $body);
+            try {
+                /** @var mixed $data */
+                $data = json_decode($body, true, 512, \JSON_THROW_ON_ERROR);
+                if (is_array($data) && isset($data['message']) && is_string($data['message'])) {
+                    $message = $data['message'];
+                }
+            } catch (\JsonException) {
+            }
         }
 
         parent::__construct($message);
 
         $this->response = $response;
+        $this->statusCode = $response->getStatusCode();
     }
 
     public function getResponse(): ResponseInterface
     {
         return $this->response;
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
     }
 }

--- a/tests/Exception/ResponseAwareExceptionTest.php
+++ b/tests/Exception/ResponseAwareExceptionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\PeakWMS\Exception;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\Http\Message\ResponseInterface;
+
+final class ResponseAwareExceptionTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @test
+     */
+    public function it_handles_json_response(): void
+    {
+        $response = $this->prophesize(ResponseInterface::class);
+        $response->getStatusCode()->willReturn(400);
+        $response->getBody()->willReturn('{"message":"OpenApi -> Order 1001127819 (CANCELLED) cannot be cancelled because it is in state CANCELLED","messageKey":null,"parameters":null,"errorCode":"4148","translateParams":false}');
+
+        $exception = new ConcreteResponseAwareException($response->reveal());
+
+        self::assertSame(400, $exception->getStatusCode());
+        self::assertSame('OpenApi -> Order 1001127819 (CANCELLED) cannot be cancelled because it is in state CANCELLED', $exception->getMessage());
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_non_json_response(): void
+    {
+        $response = $this->prophesize(ResponseInterface::class);
+        $response->getStatusCode()->willReturn(400);
+        $response->getBody()->willReturn('The API failed');
+
+        $exception = new ConcreteResponseAwareException($response->reveal());
+
+        self::assertSame(400, $exception->getStatusCode());
+        self::assertSame('The request failed with status code 400 and body: The API failed', $exception->getMessage());
+    }
+}
+
+final class ConcreteResponseAwareException extends ResponseAwareException
+{
+}


### PR DESCRIPTION
Made the `SalesOrderEndpoint::cancel` idempotent in the sense that if the order is already cancelled it will catch the exception and do nothing